### PR TITLE
Use buffer instead of string array

### DIFF
--- a/components/vanity.js
+++ b/components/vanity.js
@@ -10,6 +10,7 @@ function SHA256(data) {
 
 function checkMatch(address, start, caseSensitive, query, upperCaseQuery) {
 	var startAddress;
+	var found = false;
 	if (!start) {
 		startAddress = address.substr(address.length-query.length, query.length);
 	} else {
@@ -93,7 +94,6 @@ var generateVanityWalletCustom = function(options, progress) {
 	var upperCaseQuery = options.query.toUpperCase();
 	while(1) {
 		i++;
-		var found = false;
 		result = getBitcoinWallet();
 		var found = checkMatch(result[0], start, caseSensitive, options.query, upperCaseQuery);
 
@@ -119,7 +119,6 @@ var generateVanityWalletBitcoinJS = function(options, progress) {
 		var keyPair = bitcoin.ECPair.makeRandom();
 		var address;
 		var startAddress;
-		var found = false;
 		var redeemScript = bitcoin.script.witnessPubKeyHash.output.encode(bitcoin.crypto.hash160(keyPair.getPublicKeyBuffer()));
 		var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript));
 		address = bitcoin.address.fromOutputScript(scriptPubKey);

--- a/components/vanity.js
+++ b/components/vanity.js
@@ -1,5 +1,4 @@
 var bitcoin = require('bitcoinjs-lib');
-var CryptoJS = require('cryptojs').Crypto;
 var bs58 = require('bs58');
 var ec = require('eccrypto');
 var randomBytes = require('randombytes')
@@ -12,7 +11,7 @@ function SHA256(data) {
 var getBitcoinWallet = function (){
 
 	// passo 1 - criar uma variavel com 32 bytes randomicos
-	var privateKey = randomBytes(32)
+	var privateKey = randomBytes(32);
 
 	var publicKey = ec.getPublic(Buffer(privateKey));
 
@@ -28,7 +27,7 @@ var getBitcoinWallet = function (){
 	var hash160 = bitcoin.crypto.ripemd160(publicKeySHA256);
 
 	// passo 4 - adicionar versao na frente
-	var hashEBytes = Buffer.concat([versao,hash160]) 
+	var hashEBytes = Buffer.concat([versao,hash160]);
 
 	// passo 5 - primeiro hash sha256 do passo 4
 	var firstSHA = SHA256(hashEBytes);
@@ -49,22 +48,22 @@ var getBitcoinWallet = function (){
 }
 
 var generateWIF = function (privateKey){
-	var version = Buffer.from('80', 'hex')
+	var version = Buffer.from('80', 'hex');
 
 	// passo 1 - adicionar versao no comeco da chave privada: https://en.bitcoin.it/wiki/List_of_address_prefixes
-	var versionAndPrivateKey = Buffer.concat([version,privateKey])
+	var versionAndPrivateKey = Buffer.concat([version,privateKey]);
 
 	// passo 2 - hash sha256 do passo anterior
-	var firstSHA = SHA256(versionAndPrivateKey)
+	var firstSHA = SHA256(versionAndPrivateKey);
 
 	// passo 3 - hash sha256 do passo anterior (de novo)
-	var secondSHA = SHA256(firstSHA)
+	var secondSHA = SHA256(firstSHA);
 
 	// passo 4 - retirar os 4 primeiros bytes do passo 4 e salvar como checksum
-	var checksum = secondSHA.slice(0,4)
+	var checksum = secondSHA.slice(0,4);
 
 	// passo 5 - juntar '80' com a chave privada e adicionar o checksum ao final
-	var versionAndPrivateKeyAndChecksum = Buffer.concat([versionAndPrivateKey, checksum])
+	var versionAndPrivateKeyAndChecksum = Buffer.concat([versionAndPrivateKey, checksum]);
 
 	// passo 6 - codificar para base58
 	var wif =  bs58.encode(versionAndPrivateKeyAndChecksum);
@@ -80,7 +79,7 @@ var generateVanityWalletCustom = function(options, progress) {
 	while(1) {
 		i++;
 		var found = false;
-		var startAddress
+		var startAddress;
 		result = getBitcoinWallet();
 		if (!start) {
 			startAddress = result[0].substr(result[0].length-options.query.length, options.query.length);
@@ -98,7 +97,7 @@ var generateVanityWalletCustom = function(options, progress) {
 			return ([result[0], generateWIF(result[1]), i]);
 		}
 		if (i>1000) {
-			progress(i)
+			progress(i);
 			i = 0;
 		}
 	}
@@ -135,7 +134,7 @@ var generateVanityWalletBitcoinJS = function(options, progress) {
 			return ([address, keyPair.toWIF(), i]);
 		}
 		if (i>1000) {
-			progress(i)
+			progress(i);
 			i = 0;
 		}
 	}

--- a/components/vanity.js
+++ b/components/vanity.js
@@ -8,6 +8,21 @@ function SHA256(data) {
 	return crypto.createHash('sha256').update(data, 'utf8').digest();
 }
 
+function checkMatch(address, start, caseSensitive, query, upperCaseQuery) {
+	var startAddress;
+	if (!start) {
+		startAddress = address.substr(address.length-query.length, query.length);
+	} else {
+		startAddress = address.substr(1,query.length);
+	}
+	if (caseSensitive) {
+		found = (startAddress == query);
+	} else {
+		found = (startAddress.toUpperCase() == upperCaseQuery);
+	}
+	return found
+}
+
 var getBitcoinWallet = function (){
 
 	// passo 1 - criar uma variavel com 32 bytes randomicos
@@ -79,23 +94,14 @@ var generateVanityWalletCustom = function(options, progress) {
 	while(1) {
 		i++;
 		var found = false;
-		var startAddress;
 		result = getBitcoinWallet();
-		if (!start) {
-			startAddress = result[0].substr(result[0].length-options.query.length, options.query.length);
-		} else {
-			startAddress = result[0].substr(1,options.query.length);
-		}
-		if (caseSensitive) {
-			found = (startAddress == options.query);
-		} else {
-			found = (startAddress.toUpperCase() == upperCaseQuery);
-		}
+		var found = checkMatch(result[0], start, caseSensitive, options.query, upperCaseQuery);
 
 		if(found) {
 			console.log("Number of created addresses to find your vanity address: "+i);
 			return ([result[0], generateWIF(result[1]), i]);
 		}
+
 		if (i>1000) {
 			progress(i);
 			i = 0;
@@ -118,17 +124,7 @@ var generateVanityWalletBitcoinJS = function(options, progress) {
 		var scriptPubKey = bitcoin.script.scriptHash.output.encode(bitcoin.crypto.hash160(redeemScript));
 		address = bitcoin.address.fromOutputScript(scriptPubKey);
 
-		if (!start) {
-			startAddress = address.substr(address.length-options.query.length, options.query.length);
-		} else {
-			startAddress = address.substr(1,options.query.length);
-		}
-		if (caseSensitive) {
-			found = (startAddress == options.query);
-		} else {
-			found = (startAddress.toUpperCase() == upperCaseQuery);
-		}
-
+		var found = checkMatch(address, start, caseSensitive, options.query, upperCaseQuery);
 		if(found) {
 			console.log("Number of created addresses to find your vanity address: "+i);
 			return ([address, keyPair.toWIF(), i]);

--- a/components/vanity.js
+++ b/components/vanity.js
@@ -149,7 +149,6 @@ var generateVanityWallet = function(options, progress){
 }
 
 var generateVanityWallet = function(options, progress){
-	console.log(options)
 	if (options.walletType == "segwit") {
 		return generateVanityWalletBitcoinJS(options, progress);
 	}

--- a/components/vanity.js
+++ b/components/vanity.js
@@ -148,13 +148,6 @@ var generateVanityWallet = function(options, progress){
 	return generateVanityWalletCustom(options, progress);
 }
 
-var generateVanityWallet = function(options, progress){
-	if (options.walletType == "segwit") {
-		return generateVanityWalletBitcoinJS(options, progress);
-	}
-	return generateVanityWalletCustom(options, progress);
-}
-
 module.exports = {
 	generateVanityWallet : generateVanityWallet
 }

--- a/public/javascripts/app/custom.js
+++ b/public/javascripts/app/custom.js
@@ -156,9 +156,9 @@ function createWallet(){
 				}
 
 				if(caseSensitive == '0'){
-					$(".result-container .case-sensitive span").text('false');
+					$(".result-container .case-sensitive span").text('No');
 				}else{
-					$(".result-container .case-sensitive span").text('true');
+					$(".result-container .case-sensitive span").text('Yes');
 				}
 
 				// change buttons and options

--- a/public/javascripts/app/custom.js
+++ b/public/javascripts/app/custom.js
@@ -155,7 +155,7 @@ function createWallet(){
 					$(".result-container .string-location span").text('End with text');
 				}
 
-				if(caseSensitive == '1'){
+				if(caseSensitive == '0'){
 					$(".result-container .case-sensitive span").text('false');
 				}else{
 					$(".result-container .case-sensitive span").text('true');


### PR DESCRIPTION
- Save upper case query to improve search speed
- Use buffers instead of string arrays for performance
- Remove CryptoJS dependency
- Add missing semicolons